### PR TITLE
fix: entity behavior cache is never cleared

### DIFF
--- a/lib/src/entity.dart
+++ b/lib/src/entity.dart
@@ -20,8 +20,7 @@ abstract class Entity extends PositionComponent {
     Iterable<Component>? children,
     int? priority,
     Iterable<Behavior>? behaviors,
-  })  : _behaviors = behaviors ?? <Behavior>[],
-        assert(
+  })  : assert(
           children?.whereType<Behavior>().isEmpty ?? true,
           'Behaviors cannot be added to as a child directly.',
         ),
@@ -34,10 +33,20 @@ abstract class Entity extends PositionComponent {
           children: children,
           priority: priority,
         ) {
-    addAll(_behaviors);
+    if (behaviors != null) {
+      addAll(behaviors);
+    }
   }
 
-  final Iterable<Behavior> _behaviors;
+  late final List<Behavior> _behaviors;
+
+  @override
+  Future<void>? onLoad() {
+    children.register<Behavior>();
+    _behaviors = children.query<Behavior>();
+
+    return super.onLoad();
+  }
 
   /// Returns a list of behaviors with the given type, that are attached to
   /// this entity.

--- a/test/src/entity_test.dart
+++ b/test/src/entity_test.dart
@@ -24,5 +24,23 @@ void main() {
 
       expect(entity.children.contains(behavior), isTrue);
     });
+
+    flameTester.test(
+      'behavior can be removed from entity and the internal cache',
+      (game) async {
+        final behavior = TestBehavior();
+        final entity = TestEntity(behaviors: []);
+
+        await game.ensureAdd(entity);
+
+        expect(entity.findBehavior<TestBehavior>(), isNull);
+        await entity.ensureAdd(behavior);
+        expect(entity.findBehavior<TestBehavior>(), isNotNull);
+
+        behavior.shouldRemove = true;
+        game.update(0);
+        expect(entity.findBehavior<TestBehavior>(), isNull);
+      },
+    );
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The internal entity behavior cache was never cleared, this means that you can find behaviors that are no longer mounted. Or part of any component tree.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
