### PR TITLE
fix!: update flame dependency to v1.6.0

### DIFF
--- a/packages/flame_behaviors/lib/src/behaviors/behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/behavior.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flame/components.dart';
 import 'package:flame_behaviors/flame_behaviors.dart';
 
@@ -16,7 +18,7 @@ abstract class Behavior<Parent extends EntityMixin> extends Component
   });
 
   @override
-  Future<void>? add(Component component) {
+  FutureOr<void> add(Component component) {
     assert(component is! EntityMixin, 'Behaviors cannot have entities.');
     assert(component is! Behavior, 'Behaviors cannot have behaviors.');
     return super.add(component);

--- a/packages/flame_behaviors/pubspec.yaml
+++ b/packages/flame_behaviors/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ">=1.2.0 <2.0.0"
+  flame: ">=1.6.0 <2.0.0"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

With Flame v1.6.0 `add` method of the `Component` class has a return type of `FutureOr<void>`. Since the `Behaviour` class extends from Flame's `Component` class and overrides its `add` method, it needed to be updated.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
