### PR TITLE
fix(flame_behaviors): make `PropagatingCollisionBehavior` more open

### DIFF
--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -70,6 +70,13 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   final ShapeHitbox _hitbox;
 
   @override
+  @mustCallSuper
+  void onMount() {
+    assert(parent is PositionComponent, 'parent must be a PositionComponent');
+    super.onMount();
+  }
+
+  @override
   Future<void> onLoad() async {
     _hitbox
       ..onCollisionCallback = onCollision

--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 /// the entity that is colliding with the [Parent] is an instance of [Collider].
 /// {@endtemplate}
 abstract class CollisionBehavior<Collider extends Component,
-    Parent extends PositionedEntity> extends Behavior<Parent> {
+    Parent extends EntityMixin> extends Behavior<Parent> {
   /// Check if the given component is an instance of [Collider].
   bool isValid(Component c) => c is Collider;
 
@@ -56,8 +56,13 @@ abstract class CollisionBehavior<Collider extends Component,
 /// **Note**: This behavior can also be used for collisions between entities
 /// and non-entity components, by passing the component's type as the
 /// `Collider` to the [CollisionBehavior].
+///
+/// The parent to which this behavior is added should be a [PositionComponent]
+/// that uses the [EntityMixin]. Flame behaviors comes with the
+/// [PositionedEntity] which does exactly that but any kind of position
+/// component will work.
 /// {@endtemplate}
-class PropagatingCollisionBehavior<Parent extends PositionedEntity>
+class PropagatingCollisionBehavior<Parent extends EntityMixin>
     extends Behavior<Parent> with CollisionCallbacks {
   /// {@macro propagating_collision_behavior}
   PropagatingCollisionBehavior(this._hitbox) : super(children: [_hitbox]);

--- a/packages/flame_behaviors/test/src/behaviors/propagating_collision_behavior_test.dart
+++ b/packages/flame_behaviors/test/src/behaviors/propagating_collision_behavior_test.dart
@@ -155,11 +155,11 @@ void main() {
     flameTester.testGameWidget(
       'throws assertion exception if parent is not a positioned component',
       setUp: (game, tester) async {
-        await game.ensureAdd(_EntityD());
+        await game.ensureAdd(PositionComponent(children: [_EntityD()]));
         return game.pauseEngine(); // Pausing engine to trigger it manually
       },
       verify: (game, tester) async {
-        final entity = game.firstChild<_EntityD>()!;
+        final entity = game.descendants().whereType<_EntityD>().first;
         final propagatingCollisionBehavior = PropagatingCollisionBehavior(
           RectangleHitbox(),
         );

--- a/packages/flame_behaviors/test/src/behaviors/propagating_collision_behavior_test.dart
+++ b/packages/flame_behaviors/test/src/behaviors/propagating_collision_behavior_test.dart
@@ -155,11 +155,11 @@ void main() {
     flameTester.testGameWidget(
       'throws assertion exception if parent is not a positioned component',
       setUp: (game, tester) async {
-        await game.ensureAdd(PositionComponent(children: [_EntityD()]));
+        await game.ensureAdd(_EntityD());
         return game.pauseEngine(); // Pausing engine to trigger it manually
       },
       verify: (game, tester) async {
-        final entity = game.descendants().whereType<_EntityD>().first;
+        final entity = game.firstChild<_EntityD>()!;
         final propagatingCollisionBehavior = PropagatingCollisionBehavior(
           RectangleHitbox(),
         );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When we moved to the `EntityMixin` we forgot to update the `PropagatingCollisionBehavior` to be also mixin based so you can use any kind of position component.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
