### PR TITLE
Fix: Ensure "other's" parent is mounted before accessing in PropagatingCollisionBehavior

### DIFF
--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -106,6 +106,10 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   /// or a [Entity]. If it is neither, it will return [other].
   Component? _findEntity(PositionComponent other) {
     final parent = other.parent;
+    if (!(parent?.isMounted ?? true)) {
+      return null;
+    }
+
     if (parent is! PropagatingCollisionBehavior && parent is! Entity) {
       if (other is ShapeHitbox) {
         return other.parent;
@@ -115,7 +119,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
 
     return parent is Entity
         ? parent
-        : (parent as PropagatingCollisionBehavior?)!.parent;
+        : (parent as PropagatingCollisionBehavior?)?.parent;
   }
 
   @override


### PR DESCRIPTION
## Status

**READY**

## Description

After some recent Flame engine updates, hot-swapping component hitboxes threw an error trying to find the parent of the "other" entity collision. This checks that the other parent is mounted before contining to find the entity.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by safely handling unmounted or missing parent components during collision detection, reducing the risk of runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->