### PR TITLE
fix: Check "other" is mounted before accessing parent

### DIFF
--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -106,6 +106,10 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   /// or a [Entity]. If it is neither, it will return [other].
   Component? _findEntity(PositionComponent other) {
     final parent = other.parent;
+    if (!(parent?.isMounted ?? true)) {
+      return null;
+    }
+
     if (parent is! PropagatingCollisionBehavior && parent is! Entity) {
       if (other is ShapeHitbox) {
         return other.parent;
@@ -115,7 +119,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
 
     return parent is Entity
         ? parent
-        : (parent as PropagatingCollisionBehavior?)!.parent;
+        : (parent as PropagatingCollisionBehavior?)?.parent;
   }
 
   @override

--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -106,7 +106,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   /// or a [Entity]. If it is neither, it will return [other].
   Component? _findEntity(PositionComponent other) {
     final parent = other.parent;
-    if (!(parent?.isMounted ?? true)) {
+    if (!other.isMounted) {
       return null;
     }
 

--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -103,7 +103,8 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   /// Tries to find the entity that is colliding with the given entity.
   ///
   /// It will check if the parent is either a [PropagatingCollisionBehavior]
-  /// or a [Entity]. If it is neither, it will return [other].
+  /// or a [Entity]. If it is neither, it will return [other] or null if [other]
+  /// is not mounted.
   Component? _findEntity(PositionComponent other) {
     final parent = other.parent;
     if (!other.isMounted) {

--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -88,7 +88,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   }
 
   @override
-  Future<void> onLoad() async {
+  void onLoad() {
     _hitbox
       ..onCollisionCallback = onCollision
       ..onCollisionStartCallback = onCollisionStart

--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -35,7 +35,7 @@ abstract class CollisionBehavior<Collider extends Component,
         parent.findBehavior<PropagatingCollisionBehavior>();
 
     return propagatingCollisionBehavior.activeCollisions
-        .map(propagatingCollisionBehavior._findEntity)
+        .map(propagatingCollisionBehavior.findEntity)
         .whereType<Collider>()
         .isNotEmpty;
   }
@@ -105,7 +105,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   /// It will check if the parent is either a [PropagatingCollisionBehavior]
   /// or a [Entity]. If it is neither, it will return [other] or null if [other]
   /// is not mounted.
-  Component? _findEntity(PositionComponent other) {
+  Component? findEntity(PositionComponent other) {
     final parent = other.parent;
     if (!other.isMounted) {
       return null;
@@ -129,7 +129,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
     PositionComponent other,
   ) {
     activeCollisions.add(other);
-    final otherEntity = _findEntity(other);
+    final otherEntity = findEntity(other);
     if (otherEntity == null) {
       return;
     }
@@ -145,7 +145,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   @override
   @mustCallSuper
   void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
-    final otherEntity = _findEntity(other);
+    final otherEntity = findEntity(other);
     if (otherEntity == null) {
       return;
     }
@@ -161,7 +161,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
   @override
   void onCollisionEnd(PositionComponent other) {
     activeCollisions.remove(other);
-    final otherEntity = _findEntity(other);
+    final otherEntity = findEntity(other);
     if (otherEntity == null) {
       return;
     }

--- a/packages/flame_behaviors/test/src/behaviors/propagating_collision_behavior_test.dart
+++ b/packages/flame_behaviors/test/src/behaviors/propagating_collision_behavior_test.dart
@@ -176,6 +176,47 @@ void main() {
       },
     );
 
+    flameTester.testGameWidget(
+      '_findEntity() returns proper values during lifecycle',
+      setUp: (game, tester) async {
+        final collisionBehaviorAtoB = _CollisionBehaviorAtoB();
+        final entityA = _EntityA(
+          behaviors: [
+            PropagatingCollisionBehavior(RectangleHitbox()),
+            collisionBehaviorAtoB,
+          ],
+        );
+        final entityB = _EntityB(
+          behaviors: [PropagatingCollisionBehavior(RectangleHitbox())],
+        );
+        await game.ensureAdd(entityA);
+        await game.ensureAdd(entityB);
+        return game.pauseEngine(); // Pausing engine to trigger it manually
+      },
+      verify: (game, tester) async {
+        final entityA = game.firstChild<_EntityA>()!;
+        final entityB = game.firstChild<_EntityB>()!;
+        final collisionBehaviorAtoB =
+            entityA.firstChild<_CollisionBehaviorAtoB>()!;
+
+        final collisionPropagatingBehavior =
+            entityA.findBehavior<PropagatingCollisionBehavior>();
+
+        game.update(0);
+
+        expect(collisionBehaviorAtoB.onCollisionStartCalled, isTrue);
+        expect(collisionPropagatingBehavior.findEntity(entityB), isNotNull);
+
+        entityB.removeFromParent();
+
+        game.update(0);
+
+        expect(entityB.isMounted, isFalse);
+
+        expect(collisionPropagatingBehavior.findEntity(entityB), isNull);
+      },
+    );
+
     group('propagates collision', () {
       flameTester.testGameWidget(
         'on start to the correct collision behavior',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

After some recent Flame engine updates, hot-swapping component hitboxes threw an error trying to find the parent of the "other" entity collision. This checks that the "other" component is mounted before continuing to find the entity.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by preventing potential errors during collision detection when components are not properly mounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->